### PR TITLE
Fix piece-promotion-ui-bug

### DIFF
--- a/src/components/Cell.jsx
+++ b/src/components/Cell.jsx
@@ -4,7 +4,7 @@ import {useEffect, useState} from "react";
 import PawnPromotionOptions from "./PawnPromotionOptions";
 
 const Cell = ({isBlack, square, piece}) => {
-  const {possibleMoves} = useChess();
+  const {possibleMoves, pawnPromotion} = useChess();
   const [isPossibleMove, setIsPossibleMove] = useState(false);
 
   useEffect(() => {
@@ -19,11 +19,13 @@ const Cell = ({isBlack, square, piece}) => {
   // conditional styles
   const borderWidth = isOver ? "border-4" : null;
   const cellColor = isBlack ? "bg-yellow-700" : "bg-orange-300";
-  const backDrop = isPossibleMove ? `border-2 animate-pulse ` : null;
+  // add styling to possible moves exccept for when there is a promotion
+  const backDrop =
+    isPossibleMove && !pawnPromotion?.square ? `border-2 animate-pulse ` : null;
 
   return (
     <div
-      className={`${cellColor} w-full h-full flex justify-center items-center ${borderWidth} ${backDrop} `}
+      className={`${cellColor} w-full h-full flex justify-center items-center ${borderWidth} ${backDrop} relative`}
       ref={setNodeRef}
     >
       <PawnPromotionOptions square={square} />

--- a/src/components/PromotionOption.jsx
+++ b/src/components/PromotionOption.jsx
@@ -3,7 +3,14 @@ import pieces from "./pieces";
 
 // this is the component representing each promotion option
 const PromotionOption = ({type, color}) => {
-  const {getPGNCode, chess, pawnPromotion, setPawnPromotion, setSquares} = useChess();
+  const {
+    getPGNCode,
+    chess,
+    pawnPromotion,
+    setPawnPromotion,
+    setSquares,
+    setPossibleMoves,
+  } = useChess();
   // get where the piece is coming from and where it is to be dropped
   const {from, to} = pawnPromotion ?? {};
 
@@ -16,6 +23,8 @@ const PromotionOption = ({type, color}) => {
       setSquares(chess.board().flat());
       // promotion is done. make it null
       setPawnPromotion(null);
+      // remove all possible moves since a move has already been made
+      setPossibleMoves([]);
     }
   };
 

--- a/src/contexts/chessContext.js
+++ b/src/contexts/chessContext.js
@@ -1,4 +1,4 @@
-import {createContext, useContext, useEffect, useState} from "react";
+import {createContext, useContext, useState} from "react";
 import {Chess} from "chess.js";
 
 const ChessContext = createContext();
@@ -27,7 +27,6 @@ const isAtTheBottom = (square) => square.includes("1");
 // this exposes a couple of functions and data from the chess.js library
 const ChessProvider = ({children}) => {
   const [chess] = useState(new Chess());
-  const [history, setHistory] = useState(chess.history());
   const [squares, setSquares] = useState(chess.board().flat());
   const [pawnPromotion, setPawnPromotion] = useState(null);
   const [possibleMoves, setPossibleMoves] = useState([]);


### PR DESCRIPTION
Piece promotion options flicker due to the styling of the squares that are included in the possible moves. This commit prevents styling the possible move squares when there is a promotion