### PR TITLE
Change implementation of conditional styles to cells

### DIFF
--- a/src/components/Cell.jsx
+++ b/src/components/Cell.jsx
@@ -1,40 +1,29 @@
 import {useDroppable} from "@dnd-kit/core";
 import {useChess} from "contexts/chessContext";
-import {useEffect, useState} from "react";
 import PawnPromotionOptions from "./PawnPromotionOptions";
+import PhantomCell from "./PhantomCell";
 
 const Cell = ({isBlack, square, piece}) => {
-  const {possibleMoves, pawnPromotion, isAtTheLeft, isAtTheBottom} = useChess();
-  const [isPossibleMove, setIsPossibleMove] = useState(false);
-
-  useEffect(() => {
-    setIsPossibleMove(possibleMoves.includes(square));
-  }, [possibleMoves]);
+  const {isAtTheLeft, isAtTheBottom} = useChess();
 
   // make this cell a droppable item for the pieces
   const {isOver, setNodeRef} = useDroppable({
     id: square,
   });
 
-  // conditional styles
-  const borderColor = !isOver ? "border-transparent" : "";
   const cellColor = isBlack ? "bg-yellow-800" : "bg-amber-100";
-
-  // add styling to possible moves except for when there is a promotion
-  const backDrop =
-    isPossibleMove && !pawnPromotion?.square ? `border-white animate-pulse ` : "";
 
   return (
     <div
-      className={`${cellColor} w-full h-full flex justify-center items-center border-2 ${borderColor} ${backDrop} relative`}
+      className={`${cellColor} w-full h-full flex justify-center items-center relative`}
       ref={setNodeRef}
     >
+      <PhantomCell square={square} isOver={isOver} />
       <PawnPromotionOptions square={square} />
-      <span className="absolute top-0 left-0"> {isAtTheLeft(square) && square[1]} </span>
+      <span className="absolute top-0 left-1">{isAtTheLeft(square) && square[1]}</span>
       {piece}
-      <span className="absolute bottom-0 right-0">
-        {" "}
-        {isAtTheBottom(square) && square[0]}{" "}
+      <span className="absolute bottom-0 right-1">
+        {isAtTheBottom(square) && square[0]}
       </span>
     </div>
   );

--- a/src/components/PhantomCell.jsx
+++ b/src/components/PhantomCell.jsx
@@ -1,0 +1,33 @@
+import {useChess} from "contexts/chessContext";
+import {useEffect, useMemo, useState} from "react";
+
+// all cell hover styling will be done here
+const PhantomCell = ({square, isOver}) => {
+  const {possibleMoves, pawnPromotion} = useChess();
+  const [isPossibleMove, setIsPossibleMove] = useState(false);
+
+  useEffect(() => {
+    setIsPossibleMove(possibleMoves.includes(square));
+  }, [possibleMoves]);
+
+  const styles = useMemo(() => {
+    let style = "";
+    // adds the className if it does not exist
+    const addClass = (...classNames) => {
+      classNames.forEach((val) => {
+        if (!style.includes(val)) style += ` ${val} `;
+      });
+    };
+
+    // Conditional styles here
+    if (isOver) addClass("border-gray-100", "border-4");
+    if (isPossibleMove && !pawnPromotion?.square)
+      addClass("animate-pulse", "bg-light-green-500", "opacity-30");
+
+    return style;
+  }, [isPossibleMove, pawnPromotion, isOver]);
+
+  return <div className={`${styles} z-[1] w-full h-full absolute`}></div>;
+};
+
+export default PhantomCell;

--- a/src/components/Piece.jsx
+++ b/src/components/Piece.jsx
@@ -17,12 +17,13 @@ const Piece = ({type, color, square}) => {
   const style = transform
     ? {
         transform: `translate3d(${transform.x}px, ${transform.y}px, 0) scale(1.15)`,
-        zIndex: 5,
+        zIndex: 10,
         cursor: "grabbing",
       }
     : {
         transform: "scale(1.15)",
         cursor: "grab",
+        zIndex: 5,
       };
 
   return (

--- a/src/components/Piece.jsx
+++ b/src/components/Piece.jsx
@@ -16,12 +16,12 @@ const Piece = ({type, color, square}) => {
   // conditional styling
   const style = transform
     ? {
-        transform: `translate3d(${transform.x}px, ${transform.y}px, 0) scale(1.25)`,
+        transform: `translate3d(${transform.x}px, ${transform.y}px, 0) scale(1.15)`,
         zIndex: 5,
         cursor: "grabbing",
       }
     : {
-        transform: "scale(1.25)",
+        transform: "scale(1.15)",
         cursor: "grab",
       };
 


### PR DESCRIPTION
Instead of styling the cell itself, we add a phantom cell where we add conditional styles such as border when the cell is hovered, background if it is a possible move, etc